### PR TITLE
Remove Incorrect ContainsSecurityUpdates Attribute

### DIFF
--- a/artifacthub/durabletask-azurestorage-scaler/1.1.0/artifacthub-pkg.yml
+++ b/artifacthub/durabletask-azurestorage-scaler/1.1.0/artifacthub-pkg.yml
@@ -14,7 +14,6 @@ containersImages:
   image: ghcr.io/wsugarman/durabletask-azurestorage-scaler:1.0.0
   platforms:
   - linux/amd64
-containsSecurityUpdates: true
 keywords:
 - dtfx
 - functions

--- a/index.yaml
+++ b/index.yaml
@@ -6,7 +6,6 @@ entries:
       artifacthub.io/changes: |
         - kind: added
           description: Added support for environment variables from config maps and secrets
-      artifacthub.io/containsSecurityUpdates: "true"
       artifacthub.io/images: |
         - name: durabletask-azurestorage-scaler
           image: ghcr.io/wsugarman/durabletask-azurestorage-scaler:1.0.0


### PR DESCRIPTION
`durabletask-azurestorage-scaler` version 1.1.0 does not contain security updates, and as such the attribute will be removed from the Artifact Hub metadata (although not the chart file itself).