### PR TITLE
Revert "Remove Incorrect ContainsSecurityUpdates Attribute"

### DIFF
--- a/artifacthub/durabletask-azurestorage-scaler/1.1.0/artifacthub-pkg.yml
+++ b/artifacthub/durabletask-azurestorage-scaler/1.1.0/artifacthub-pkg.yml
@@ -14,6 +14,7 @@ containersImages:
   image: ghcr.io/wsugarman/durabletask-azurestorage-scaler:1.0.0
   platforms:
   - linux/amd64
+containsSecurityUpdates: true
 keywords:
 - dtfx
 - functions

--- a/index.yaml
+++ b/index.yaml
@@ -6,6 +6,7 @@ entries:
       artifacthub.io/changes: |
         - kind: added
           description: Added support for environment variables from config maps and secrets
+      artifacthub.io/containsSecurityUpdates: "true"
       artifacthub.io/images: |
         - name: durabletask-azurestorage-scaler
           image: ghcr.io/wsugarman/durabletask-azurestorage-scaler:1.0.0


### PR DESCRIPTION
Undo metadata update. The incorrect metadata is in the archived chart, so at least this way the metadata matches.

Reverts wsugarman/charts#8